### PR TITLE
fix wrong formatting with "0D" pattern

### DIFF
--- a/src/main/java/io/reliza/versioning/Version.java
+++ b/src/main/java/io/reliza/versioning/Version.java
@@ -245,7 +245,7 @@ public class Version implements Comparable<Version> {
 					if (this.day < 10) {
 						versionString.append("0");
 					}
-					versionString.append(this.year.toString());
+					versionString.append(this.day.toString());
 					break;
 				default:
 					break;


### PR DESCRIPTION
I found when using `0D` pattern versioning API returns year string.